### PR TITLE
feat: login

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,0 +1,73 @@
+describe('Signup page', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/auth/login');
+  });
+
+  describe('Form', () => {
+    it('should display the form', () => {
+      cy.get('[data-cy=login-form]').should('exist');
+    });
+
+    it('should display the title', () => {
+      cy.get('[data-cy=title]').should('exist');
+    });
+
+    it('should display the email input', () => {
+      cy.get('[data-cy=email-input]').should('exist');
+    });
+
+    it('should display the password input', () => {
+      cy.get('[data-cy=password-input]').should('exist');
+    });
+
+    it('should display the submit button', () => {
+      cy.get('[data-cy=submit-button]').should('exist');
+    });
+  });
+
+  describe('Form validation', () => {
+    it('should display an error message when email is invalid', () => {
+      cy.get('[data-cy=email-input]').type('invalid-email');
+      cy.get('[data-cy=submit-button]').click();
+      cy.get('[data-cy=email-error]').should('exist').should('have.text', '*Invalid email');
+    });
+
+    it('should display an error message when email is empty', () => {
+      cy.get('[data-cy=submit-button]').click();
+      cy.get('[data-cy=email-error]').should('exist').should('have.text', '*Required');
+    });
+
+    it('should display an error message when password is empty', () => {
+      cy.get('[data-cy=submit-button]').click();
+      cy.get('[data-cy=password-error]').should('exist').should('have.text', '*Required');
+    });
+  });
+
+  describe('Form submission', () => {
+    it('should redirect to home page when form is submitted', () => {
+      cy.intercept('POST', '/Auth/Login', {
+        statusCode: 200,
+        body: {
+          success: true,
+          token: 'token',
+          publicKey: 'publicKey',
+        },
+      }).as('successfulLogin');
+      cy.get('[data-cy=email-input]').type('valid@email.com');
+      cy.get('[data-cy=password-input]').type('password');
+      cy.get('[data-cy=submit-button]').click();
+      cy.wait('@successfulLogin');
+      cy.url().should('eq', 'http://localhost:3000/home');
+    });
+
+    it('should not redirect to home page when form is submitted with invalid credentials', () => {
+      cy.intercept('POST', '/Auth/Login', {
+        statusCode: 400,
+      }).as('failedLogin');
+      cy.get('[data-cy=email-input]').type('invalid@email.com');
+      cy.get('[data-cy=password-input]').type('password');
+      cy.get('[data-cy=submit-button]').click();
+      cy.url().should('eq', 'http://localhost:3000/auth/login');
+    });
+  });
+});

--- a/src/app/auth/login/components/LoginForm.tsx
+++ b/src/app/auth/login/components/LoginForm.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Formik } from 'formik';
+import React from 'react';
+import { toast, Toaster } from 'sonner';
+import { ILoginResponse, LoginInitialValues, LoginRequest } from '../utils/constants';
+import { LoginUserSchema } from '../utils/login-user-schema';
+import styles from '../styles/LoginForm.module.css';
+import SignUpInput from '../../signup/components/sign-up-form/SignUpInput';
+import { EmailIcon } from '../../signup/components/sign-up-form/icons/email';
+import { KeyIcon } from '../../signup/components/sign-up-form/icons/key';
+import axiosInstance from '@/services/axios-instance';
+import { useRouter } from 'next/navigation';
+
+const LoginForm = () => {
+  const router = useRouter();
+
+  return (
+    <>
+      <Toaster position='top-right' />
+      <Formik
+        initialValues={LoginInitialValues}
+        validationSchema={LoginUserSchema}
+        onSubmit={(values, { setSubmitting }) => {
+          setSubmitting(true);
+
+          toast.promise(
+            new Promise<void>((resolve) => {
+              setTimeout(() => {
+                resolve();
+              }, 500);
+            }),
+            {
+              loading: 'Logging in...',
+            },
+          );
+
+          const loginRequest = new LoginRequest(values.email, values.password);
+
+          axiosInstance
+            .post('/Auth/Login', loginRequest)
+            .then((response) => {
+              toast.success('Logged in successfully!', {
+                style: {
+                  background: 'green',
+                  color: 'white',
+                },
+              });
+
+              const responsePayload: ILoginResponse = response.data;
+
+              localStorage.setItem('ACCESS_TOKEN', responsePayload.token);
+              localStorage.setItem('PUBLIC_KEY', responsePayload.publicKey);
+
+              router.push('/home');
+            })
+            .catch((error) => {
+              console.error(error);
+              toast.error(error?.response.data ?? "Error loggin in...", {
+                style: {
+                  background: 'red',
+                  color: 'white',
+                },
+              });
+            })
+            .finally(() => {
+              setSubmitting(false);
+            });
+        }}
+      >
+        {({ values, errors, touched, handleChange, handleBlur, handleSubmit, isSubmitting }) => (
+          <form className={styles.form} onSubmit={handleSubmit} data-cy='login-form'>
+            <p className={styles.signInTitle} data-cy='title'>
+              Welcome to Crippy!
+            </p>
+            <SignUpInput
+              type='email'
+              name='email'
+              handleChange={handleChange}
+              handleBlur={handleBlur}
+              error={errors.email}
+              value={values.email}
+              touched={touched.email}
+              label='Email'
+              icon={EmailIcon}
+            />
+
+            <SignUpInput
+              type='password'
+              name='password'
+              handleChange={handleChange}
+              handleBlur={handleBlur}
+              error={errors.password}
+              value={values.password}
+              touched={touched.password}
+              label='Password'
+              icon={KeyIcon}
+            />
+            <button
+              type='submit'
+              className={styles.submitButton}
+              disabled={isSubmitting}
+              data-cy='submit-button'
+            >
+              Submit
+            </button>
+          </form>
+        )}
+      </Formik>
+    </>
+  );
+};
+
+export default LoginForm;

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import LoginForm from "./components/LoginForm";
+import styles from "./styles/LoginPage.module.css";
+
+const Login = () => {
+    return (
+        <div className={styles.container}>
+            <LoginForm />
+        </div>
+    );
+}
+
+export default Login;

--- a/src/app/auth/login/styles/LoginForm.module.css
+++ b/src/app/auth/login/styles/LoginForm.module.css
@@ -1,0 +1,17 @@
+.form {
+  @apply place-items-center;
+  display: flex;
+  flex-direction: column;
+  width: 75%;
+  max-height: 100vh;
+}
+
+.signInTitle {
+  margin-bottom: 1.5rem;
+  font-size: xx-large;
+}
+
+.submitButton {
+  @apply btn btn-wide bg-main-blue-700 text-white hover:bg-main-blue-800;
+}
+

--- a/src/app/auth/login/styles/LoginPage.module.css
+++ b/src/app/auth/login/styles/LoginPage.module.css
@@ -1,0 +1,7 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100%;
+}

--- a/src/app/auth/login/utils/constants.ts
+++ b/src/app/auth/login/utils/constants.ts
@@ -1,0 +1,22 @@
+import { ILoginUser } from '@/models/login-user';
+
+export const LoginInitialValues: ILoginUser = {
+  email: '',
+  password: '',
+};
+
+export class LoginRequest {
+  email: string;
+  password: string;
+
+  constructor(email: string, password: string) {
+    this.email = email;
+    this.password = password;
+  }
+}
+
+export interface ILoginResponse {
+  success: boolean;
+  token: string;
+  publicKey: string;
+}

--- a/src/app/auth/login/utils/login-user-schema.ts
+++ b/src/app/auth/login/utils/login-user-schema.ts
@@ -1,0 +1,11 @@
+import * as Yup from 'yup';
+
+const errors = {
+  required: '*Required',
+  invalidEmail: '*Invalid email',
+};
+
+export const LoginUserSchema = Yup.object().shape({
+  email: Yup.string().email(errors.invalidEmail).required(errors.required),
+  password: Yup.string().required(errors.required),
+});

--- a/src/models/login-user.ts
+++ b/src/models/login-user.ts
@@ -1,0 +1,4 @@
+export interface ILoginUser {
+    email: string;
+    password: string;
+}


### PR DESCRIPTION
# Summary

- Add interface `ILoginUser`.
- Add constants for login form.
- Add login user validation schema using `yup`.
- Add `LoginForm` component and styles.
- Add `LoginPage` component and styles.
- Add `Cypress` tests for the login page.

# Details

- Users can now login to the platform.

# Evidences

## Login page
![form](https://github.com/user-attachments/assets/1d8adda3-0e60-42e7-91af-f49836585fad)

## Login form validations
![form-errors](https://github.com/user-attachments/assets/55ce5dfc-a000-4e06-afca-5d635090e010)

## Successful login
![login-success](https://github.com/user-attachments/assets/b25ab68a-523e-4aa0-8e50-0bf98aa15ede)

## Login error
![login-error](https://github.com/user-attachments/assets/3475c9a2-1b97-4317-92c4-7090bd35e0b8)
