### PR TITLE
ref: balances add issuer

### DIFF
--- a/cypress/fixtures/dashboard/balances.json
+++ b/cypress/fixtures/dashboard/balances.json
@@ -4,11 +4,13 @@
         "balances": [
             {
                 "asset": "ETH",
-                "amount": "0.0002000"
+                "amount": "0.0002000",
+                "issuer": "someEthIssuer"
             },
             {
                 "asset": "BTC",
-                "amount": "0.0001000"
+                "amount": "0.0001000",
+                "issuer": "someBtcIssuer"
             }
         ]
     },

--- a/cypress/fixtures/dashboard/filtered-balances.json
+++ b/cypress/fixtures/dashboard/filtered-balances.json
@@ -4,7 +4,8 @@
         "balances": [
             {
                 "asset": "ETH",
-                "amount": "0.0002000"
+                "amount": "0.0002000",
+                "issuer": "someEthIssuer"
             }
         ],
         "totalPages": 1

--- a/cypress/fixtures/dashboard/test-balances.json
+++ b/cypress/fixtures/dashboard/test-balances.json
@@ -4,7 +4,8 @@
         "balances": [
             {
                 "asset": "XLM",
-                "amount": "10000.0000000"
+                "amount": "10000.0000000",
+                "issuer": "native"
             }
         ]
     },

--- a/src/app/dashboard/components/BalanceCard.tsx
+++ b/src/app/dashboard/components/BalanceCard.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { IBalance } from '../interfaces/balances-response.interface';
 import styles from '../styles/BalanceCard.module.css';
 
-const BalanceCard = ({ asset, amount }: IBalance) => {
+const BalanceCard = ({ asset, amount, issuer }: IBalance) => {
   return (
     <div className={styles.container} data-cy={`balance-card-${asset.toLowerCase()}`}>
       <div className={styles.cardBody}>
         <h2 className={styles.cardTitle}>Asset: {asset == 'native' ? 'XLM' : asset}</h2>
         <p>Amount: {amount}</p>
+        <p>Issuer: {issuer}</p>
         <div className={styles.cardAction}>
           <button className={styles.cardButton}>Send</button>
         </div>

--- a/src/app/dashboard/interfaces/balances-response.interface.ts
+++ b/src/app/dashboard/interfaces/balances-response.interface.ts
@@ -8,6 +8,7 @@ export interface IBalancesResponseBody {
 export interface IBalance {
   asset: string;
   amount: string;
+  issuer: string;
 }
 
 export interface IBalancesResponse {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -87,7 +87,7 @@ const Page = () => {
 
   return (
     <div className={styles.container} data-cy='balances-section'>
-      <Toaster position='top-right' data-cy="balances-toast"/>
+      <Toaster position='top-right' data-cy='balances-toast' />
       <h2 className={styles.title} data-cy='balances-title'>
         Balances
       </h2>
@@ -127,7 +127,12 @@ const Page = () => {
           isLoading ? (
             <LoadingBalance key={balance.asset} />
           ) : (
-            <BalanceCard key={balance.asset} asset={balance.asset} amount={balance.amount} />
+            <BalanceCard
+              key={balance.asset}
+              asset={balance.asset}
+              amount={balance.amount}
+              issuer={balance.issuer}
+            />
           ),
         )}
       </div>

--- a/src/app/dashboard/styles/BalanceCard.module.css
+++ b/src/app/dashboard/styles/BalanceCard.module.css
@@ -1,5 +1,5 @@
 .container {
-    @apply card w-80 h-44 bg-main-blue-950 opacity-90 hover:shadow-lg hover:shadow-main-blue-400;
+    @apply card w-80 h-52 bg-main-blue-950 opacity-90 hover:shadow-lg hover:shadow-main-blue-400;
 }
 
 .cardBody {


### PR DESCRIPTION
# Summary

- Update `IBalance` interface by adding the `issuer` attribute.
- Refactor `BalanceCard` component to display asset issuer's public key.
- Increase `BalanceCard` height.
- Add issuers in the balances `Cypress` `fixtures`.
- Update `dashboard` page to pass the asset issuers to the balance cards.

# Details 

- Users can now view each asset issuer, allowing them to verify its authenticity.

# Evidences

## Dashboard page
![image](https://github.com/user-attachments/assets/3f8b4c15-57c5-42f6-86ad-d629c049cfc0)
